### PR TITLE
Enhance logic to apply defaults

### DIFF
--- a/src/classes/TestFactory.cls
+++ b/src/classes/TestFactory.cls
@@ -87,7 +87,7 @@ public class TestFactory {
 	}
 
 	private static void addFieldDefaults(SObject sObj, Map<Schema.SObjectField, Object> defaults) {
-		// Loop through the map of fields and if they are null on the object, fill them.
+		// Loop through the map of fields and if they weren't specifically assigned, fill them.
 		Map<String, Object> populatedFields = sObj.getPopulatedFieldsAsMap();
         	for (Schema.SObjectField field : defaults.keySet()) {
 			if (!populatedFields.containsKey(String.valueOf(field))) {

--- a/src/classes/TestFactory.cls
+++ b/src/classes/TestFactory.cls
@@ -88,8 +88,9 @@ public class TestFactory {
 
 	private static void addFieldDefaults(SObject sObj, Map<Schema.SObjectField, Object> defaults) {
 		// Loop through the map of fields and if they are null on the object, fill them.
-		for (Schema.SObjectField field : defaults.keySet()) {
-			if (sObj.get(field) == null) {
+		Map<String, Object> populatedFields = sObj.getPopulatedFieldsAsMap();
+        	for (Schema.SObjectField field : defaults.keySet()) {
+			if (!populatedFields.containsKey(String.valueOf(field))) {
 				sObj.put(field, defaults.get(field));
 			}
 		}


### PR DESCRIPTION
Ran into a problem where I wanted to specifically null a field that was non-null in the defaults class. Checking for a null value doesn't handle this scenario. Moved to the recently improved getPopulatedFieldsAsMap method to see what the user specifically assigned value (or absence of value) on the object and add values where the user hasn't specified anything.