### PR TITLE
Separated ObjectDefaults classes from test factory logic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Usage:
     Opportunity o = (Opportunity)TestFactory.createSObject(new Opportunity(AccountId = a.Id));
     
     // You can also specify a specific set of overrides for different scenarios
-    Account a = (Account)TestFactory.createSObject(new Account(), 'TestFactory.AccountDefaults');
+    Account a = (Account)TestFactory.createSObject(new Account(), 'AccountDefaults');
     
     // Finally, get a bunch of records for testing bulk
     Account[] aList = (Account[])TestFactory.createSObjectList(new Account(), 200);

--- a/src/classes/TestFactory.cls
+++ b/src/classes/TestFactory.cls
@@ -5,9 +5,9 @@ public class TestFactory {
 		// Check what type of object we are creating and add any defaults that are needed.
 		String objectName = String.valueOf(sObj.getSObjectType());
 		// Construct the default values class. Salesforce doesn't allow '__' in class names
-		String defaultClassName = 'TestFactory.' + objectName.replaceAll('__(c|C)$|__', '') + 'Defaults';
+		String defaultClassName = objectName.replaceAll('__(c|C)$|__', '') + 'Defaults';
 		// If there is a class that exists for the default values, then use them
-		if (Type.forName(defaultClassName) != null) {
+		if (Type.forName('TestFactoryDefaults.' + defaultClassName) != null) {
 			sObj = createSObject(sObj, defaultClassName);
 		}
 		return sObj;
@@ -23,7 +23,7 @@ public class TestFactory {
 
 	public static SObject createSObject(SObject sObj, String defaultClassName) {
 		// Create an instance of the defaults class so we can get the Map of field defaults
-		Type t = Type.forName(defaultClassName);
+		Type t = Type.forName('TestFactoryDefaults.' + defaultClassName);
 		if (t == null) {
 			Throw new TestFactoryException('Invalid defaults class.');
 		}
@@ -89,7 +89,7 @@ public class TestFactory {
 	private static void addFieldDefaults(SObject sObj, Map<Schema.SObjectField, Object> defaults) {
 		// Loop through the map of fields and if they weren't specifically assigned, fill them.
 		Map<String, Object> populatedFields = sObj.getPopulatedFieldsAsMap();
-        	for (Schema.SObjectField field : defaults.keySet()) {
+		for (Schema.SObjectField field : defaults.keySet()) {
 			if (!populatedFields.containsKey(String.valueOf(field))) {
 				sObj.put(field, defaults.get(field));
 			}
@@ -107,43 +107,5 @@ public class TestFactory {
 	// Use the FieldDefaults interface to set up values you want to default in for all objects.
 	public interface FieldDefaults {
 		Map<Schema.SObjectField, Object> getFieldDefaults();
-	}
-
-	// To specify defaults for objects, use the naming convention [ObjectName]Defaults.
-	// For custom objects, omit the __c from the Object Name
-
-	public class AccountDefaults implements FieldDefaults {
-		public Map<Schema.SObjectField, Object> getFieldDefaults() {
-			return new Map<Schema.SObjectField, Object> {
-				Account.Name => 'Test Account'
-			};
-		}
-	}
-
-	public class ContactDefaults implements FieldDefaults {
-		public Map<Schema.SObjectField, Object> getFieldDefaults() {
-			return new Map<Schema.SObjectField, Object> {
-				Contact.FirstName => 'First',
-				Contact.LastName => 'Last'
-			};
-		}
-	}
-
-	public class OpportunityDefaults implements FieldDefaults {
-		public Map<Schema.SObjectField, Object> getFieldDefaults() {
-			return new Map<Schema.SObjectField, Object> {
-				Opportunity.Name => 'Test Opportunity',
-				Opportunity.StageName => 'Closed Won',
-				Opportunity.CloseDate => System.today()
-			};
-		}
-	}
-
-	public class CaseDefaults implements FieldDefaults {
-		public Map<Schema.SObjectField, Object> getFieldDefaults() {
-			return new Map<Schema.SObjectField, Object> {
-				Case.Subject => 'Test Case'
-			};
-		}
 	}
 }

--- a/src/classes/TestFactoryDefaults.cls
+++ b/src/classes/TestFactoryDefaults.cls
@@ -1,0 +1,49 @@
+@IsTest
+public  class TestFactoryDefaults{
+
+    // To specify defaults for objects, use the naming convention [ObjectName]Defaults.
+    // For custom objects, omit the __c from the Object Name
+
+    public class AccountDefaults implements TestFactory.FieldDefaults {
+        public Map<Schema.SObjectField, Object> getFieldDefaults() {
+            return new Map<Schema.SObjectField, Object> {
+                    Account.Name => 'Test Account'
+            };
+        }
+    }
+
+    public class MyAccountDefaults implements TestFactory.FieldDefaults {
+        public Map<Schema.SObjectField, Object> getFieldDefaults() {
+            return new Map<Schema.SObjectField, Object> {
+                    Account.Name => 'My Test Account'
+            };
+        }
+    }
+
+    public class ContactDefaults implements TestFactory.FieldDefaults {
+        public Map<Schema.SObjectField, Object> getFieldDefaults() {
+            return new Map<Schema.SObjectField, Object> {
+                    Contact.FirstName => 'First',
+                    Contact.LastName => 'Last'
+            };
+        }
+    }
+
+    public class OpportunityDefaults implements TestFactory.FieldDefaults {
+        public Map<Schema.SObjectField, Object> getFieldDefaults() {
+            return new Map<Schema.SObjectField, Object> {
+                    Opportunity.Name => 'Test Opportunity',
+                    Opportunity.StageName => 'Closed Won',
+                    Opportunity.CloseDate => System.today()
+            };
+        }
+    }
+
+    public class CaseDefaults implements TestFactory.FieldDefaults {
+        public Map<Schema.SObjectField, Object> getFieldDefaults() {
+            return new Map<Schema.SObjectField, Object> {
+                    Case.Subject => 'Test Case'
+            };
+        }
+    }
+}

--- a/src/classes/TestFactoryTest.cls
+++ b/src/classes/TestFactoryTest.cls
@@ -1,0 +1,87 @@
+@IsTest
+private class TestFactoryTest{
+
+    @IsTest
+    static void when_objectIsCreated_expect_defaultFieldsArePopulated(){
+        //when
+        Account a = (Account)TestFactory.createSObject(new Account());
+        //then
+        System.assertEquals('Test Account', a.Name, 'Expecting Default field value is set to specific value');
+    }
+
+    @IsTest
+    static void when_objectIsInserted_expect_defaultFieldsArePopulated(){
+        //when
+        Account a = (Account)TestFactory.createSObject(new Account(),true);
+        //then
+        a = [SELECT Name FROM Account WHERE Id = :a.Id];
+        System.assertEquals('Test Account', a.Name, 'Expecting Default field value is set to specific value');
+    }
+
+    @IsTest
+    static void when_objectIsCreatedWithSpecificDefaultsSet_expect_defaultFieldsArePopulated(){
+        //when
+        Account a = (Account)TestFactory.createSObject(new Account(), 'MyAccountDefaults');
+        //then
+        System.assertEquals('My Test Account', a.Name, 'Expecting Default field value is set to specific value');
+    }
+
+    @IsTest
+    static void when_objectIsInsertedWithSpecificDefaultsSet_expect_defaultFieldsArePopulated(){
+        //when
+        Account a = (Account)TestFactory.createSObject(new Account(), 'MyAccountDefaults', true);
+        //then
+        System.assertEquals('My Test Account', a.Name, 'Expecting Default field value is set to specific value');
+    }
+
+    @IsTest
+    static void when_ListOfObjectsIsCreated_expect_defaultFieldsArePopulated(){
+        //when
+        Account[] aList = (Account[])TestFactory.createSObjectList(new Account(), 200);
+        //then
+        for(Account a : aList){
+            System.assert(a.Name.startsWith('Test Account'), 'Expecting Default field value is set to specific value');
+        }
+    }
+
+    @IsTest
+    static void when_ListOfObjectIsInserted_expect_defaultFieldsArePopulated(){
+        //when
+        Account[] aList = (Account[])TestFactory.createSObjectList(new Account(), 200, true);
+        Set<Id> accountIds = new Set<Id>();
+        for(Account account : aList){
+            accountIds.add(account.Id);
+        }
+        //then
+        aList = [SELECT Name FROM Account WHERE Id IN :accountIds ORDER BY Name];
+        for(Account a : aList){
+            System.assert(a.Name.startsWith('Test Account'), 'Expecting Default field value is set to specific value');
+        }
+    }
+
+    @IsTest
+    static void when_ListOfObjectsIsCreatedWithSpecificDefaultsSet_expect_defaultFieldsArePopulated(){
+        //when
+        Account[] aList = (Account[])TestFactory.createSObjectList(new Account(), 200, 'MyAccountDefaults');
+        //then
+        for(Account a : aList){
+            System.assert(a.Name.startsWith('My Test Account'), 'Expecting Default field value is set to specific value');
+        }
+    }
+
+    @IsTest
+    static void when_ListOfObjectsIsInsertedWithSpecificDefaultsSet_expect_defaultFieldsArePopulated(){
+        //when
+        Account[] aList = (Account[])TestFactory.createSObjectList(new Account(), 200, 'MyAccountDefaults', true);
+        Set<Id> accountIds = new Set<Id>();
+        for(Account account : aList){
+            accountIds.add(account.Id);
+        }
+        //then
+        aList = [SELECT Name FROM Account WHERE Id IN :accountIds ORDER BY Name];
+        for(Account a : aList){
+            System.assert(a.Name.startsWith('My Test Account'), 'Expecting Default field value is set to specific value');
+        }
+    }
+
+}


### PR DESCRIPTION
Separated ObjectDefaults classes from test factory logic. Changed the way of specifying a specific set of overrides for different scenarios (now prefix for Class name is no longer needed) and also created set of unit tests