### PR TITLE
Update regex to remove all _ for custom object

### DIFF
--- a/src/classes/TestFactory.cls
+++ b/src/classes/TestFactory.cls
@@ -5,7 +5,7 @@ public class TestFactory {
     // Check what type of object we are creating and add any defaults that are needed.
     String objectName = String.valueOf(sObj.getSObjectType());
     // Construct the default values class. Salesforce doesn't allow '__' in class names
-    String defaultClassName = objectName.replaceAll('__(c|C)$|__', '') + 'Defaults';
+    String defaultClassName = objectName.replaceAll('__(c|C)$|_', '') + 'Defaults';
     // If there is a class that exists for the default values, then use them
     if(Type.forName('TestFactoryDefaults.' + defaultClassName) != null) {
       sObj = createSObject(sObj, 'TestFactoryDefaults.' + defaultClassName);


### PR DESCRIPTION
Hi there, 

Not sure if it was intended to be like this or if it's a bug. There is an extra '_' in the last bit of the regex that shouldn't be there. 
Currently 'Course_Fee__c' is transformed to 'Course_FeeDefaults', instead of 'CourseFeeDefaults'. 

Cheers,
 
David