### PR TITLE
CaseComment does not have a name field

### DIFF
--- a/force-app/main/default/classes/TestFactory.cls
+++ b/force-app/main/default/classes/TestFactory.cls
@@ -76,12 +76,12 @@ public class TestFactory {
 		if (nameField == null) {
 			nameField = 'Name';
 		}
-        Boolean nameIsAutoNumber = sObj.getSobjectType().getDescribe().fields.getMap().get(nameField).getDescribe().isAutoNumber();
+        Boolean nameIsAutoNumber = sObj.getSobjectType().getDescribe().fields.getMap().get(nameField)?.getDescribe().isAutoNumber();
 
 		// Clone the object the number of times requested. Increment the name field so each record is unique
 		for (Integer i = 0; i < numberOfObjects; i++) {
 			SObject clonedSObj = newObj.clone(false, true);
-            if (!nameIsAutoNumber) {
+            if (nameIsAutoNumber == false) {
 				clonedSObj.put(nameField, (String)clonedSObj.get(nameField) + ' ' + i);
             }
 			sObjs.add(clonedSObj);

--- a/force-app/main/default/classes/TestFactory.cls-meta.xml
+++ b/force-app/main/default/classes/TestFactory.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>60.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/TestFactoryDefaults.cls-meta.xml
+++ b/force-app/main/default/classes/TestFactoryDefaults.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>60.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/TestFactoryTest.cls-meta.xml
+++ b/force-app/main/default/classes/TestFactoryTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>60.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -10,7 +10,7 @@
     ],
     "namespace": "",
     "sfdcLoginUrl": "https://login.salesforce.com",
-    "sourceApiVersion": "45.0",
+    "sourceApiVersion": "60.0",
     "packageAliases": {
         "salesforce-test-factory": "0Ho2G000000KyjLSAS",
         "salesforce-test-factory@1.0.0-1": "04t2G000000Y19lQAC"


### PR DESCRIPTION
When creating test CaseComments this breaks because there is not a name field. 

Adding a safe navigation operator and then checking for equal to false rather than is not true.